### PR TITLE
enh: set titlesize and -weight for supxlabel and supylabel

### DIFF
--- a/src/matplotlibrc
+++ b/src/matplotlibrc
@@ -2,6 +2,8 @@
 
 # Figure
 figure.figsize: 8.0, 4.5
+figure.titlesize: 13
+figure.titleweight: 500
 
 # Texts
 text.color: 505050


### PR DESCRIPTION
Add titlesize and titleweight styles to the matplotlibrc